### PR TITLE
Mark C# source code with 'lang'

### DIFF
--- a/source/blog/2015/03-22-on-how-jet-chose.md
+++ b/source/blog/2015/03-22-on-how-jet-chose.md
@@ -33,6 +33,7 @@ Like many large-scale projects, we needed a way to handle validation, logging, a
 
 For example, to ensure authorization for an entire controller named MyController, you could use the following code:
 
+	[lang=csharp]
 	[Authorize]
 	public class MyController
 	{


### PR DESCRIPTION
Without this, the code is sent to the F# compiler when formatting snippets. This confuses the compiler and as a result, most tooltips won't work.

I _think_ this is the right syntax, but better check it before merging :-)